### PR TITLE
Add Farsi label support and setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ python fasttog.py \
 --kg_graph_file_name visulize \
 --community_max_size 4
 ```
+
+### Farsi sample database
+For a quick end-to-end demo using a tiny Farsi subset of Wikidata, simply run:
+
+```
+bash run_wikidata_fa.sh
+```
+
+The script installs dependencies, loads `wikidata_sample.cypher` into Neo4j, and answers a Farsi example question.
+
+
 ## 🤔Arguments
 * **query** question you want to ask
 * **entity** subjectival entity of you question. You should check the entity exist in the KG before running the script

--- a/fasttog.py
+++ b/fasttog.py
@@ -737,6 +737,8 @@ parser.add_argument("--kg_user", type=str, required=True,
                     default="", help="user for knowledge graph engine")
 parser.add_argument("--kg_pw", type=str, required=True,
                     default="", help="password for knowledge graph engine")
+parser.add_argument("--kg_label_property", type=str,
+                    default="label", help="node property storing entity labels")
 parser.add_argument("--kg_graph_file_name", type=str,
                     default="visual", help="path for visualization of local graph, nonable")
 #G2T specification
@@ -748,7 +750,8 @@ parser.add_argument("--graph2text_max_length", type=int,
 if __name__ == "__main__":
     args = parser.parse_args()
     
-    kg_cli = neo4j_client(args.kg_api, args.kg_user, args.kg_pw)
+    kg_cli = neo4j_client(args.kg_api, args.kg_user, args.kg_pw,
+                          label_property=args.kg_label_property)
     llm_cli = llm_client(url=args.llm_api, 
                      api_key=args.llm_api_key, 
                      models=args.llm_model,

--- a/kg_client.py
+++ b/kg_client.py
@@ -2,12 +2,28 @@ import neo4j
 import numpy as np
 from collections import deque
 
+
 class neo4j_client():
-    def __init__(self, uri, user, password, log_path=None):
+    def __init__(self, uri, user, password, label_property: str = "label", log_path=None):
+        """Create a neo4j client.
+
+        Args:
+            uri: neo4j server uri, e.g. bolt://localhost:7687
+            user: user name for neo4j
+            password: password for neo4j
+            label_property: property name used to store entity label in the
+                database.  By default the project stores the English label in a
+                field called ``label``.  When using another language (e.g.
+                Farsi) import the label into a different field and pass the
+                field name here.
+            log_path: optional path for writing error logs
+        """
+
         self.driver = neo4j.GraphDatabase.driver(uri, auth=(user, password))
+        self.label_property = label_property
         self.log_path = log_path
         if self.log_path:
-            f = open(log_path, 'w')
+            f = open(log_path, "w")
             f.close()
     
     def runCQL(self, cql, print_cql=False):
@@ -37,7 +53,7 @@ class neo4j_client():
         status,content = self.get_node(start_node_id, print_cql)
         if status == 0:
             return result
-        node_id,node_label,node_alias = content[0],content[1],content[2]
+        node_id, node_label, node_alias = content[0], content[1], content[2]
         queue = deque([(node_id, node_label, hop_count)])  # (id, node, rel, hop_count)
         while queue:
             node_id, node_label, hop_count = queue.popleft() #has been exlcuded
@@ -63,7 +79,7 @@ class neo4j_client():
         res = self.runCQL(CQL, print_cql)
         if res != -1 and res is not None:
             if len(res) > 0:
-                return 1,(res[0]['n']['nid'], res[0]['n']['label'], res[0]['n'].get('alias'))
+                return 1,(res[0]['n']['nid'], res[0]['n'][self.label_property], res[0]['n'].get('alias'))
             else:
                 return 0,None
         else:
@@ -72,13 +88,15 @@ class neo4j_client():
     
     #return entity by label
     def get_node_by_label(self, label, print_cql=False):
-        CQL = "MATCH (n:Entity) \n\
-               WHERE n.label = '%s' \n\
-               RETURN n"%label
+        CQL = (
+            "MATCH (n:Entity) \n"
+            f"       WHERE n.{self.label_property} = '{label}' \n"
+            "       RETURN n"
+        )
         res = self.runCQL(CQL, print_cql)
         if res != -1 and res is not None:
             if len(res) > 0:
-                return 1,(res[0]['n']['nid'], res[0]['n']['label'], res[0]['n'].get('alias'))
+                return 1,(res[0]['n']['nid'], res[0]['n'][self.label_property], res[0]['n'].get('alias'))
             else:
                 return 0,None
         else:
@@ -97,7 +115,7 @@ class neo4j_client():
         if res != -1 and res is not None:
             for index in range(len(res)):
                 nrn_json = res[index]
-                node_list.append({'nid':nrn_json['n2']['nid'], 'label':nrn_json['n2']['label']})
+                node_list.append({'nid': nrn_json['n2']['nid'], 'label': nrn_json['n2'][self.label_property]})
         return node_list
 
     #RETURN relation among node with nid in nid_set format: {n1.nid, r.value, n2.nid}

--- a/run_wikidata_fa.sh
+++ b/run_wikidata_fa.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Script to set up and run FastToG with a Farsi Wikidata neo4j database.
+# It installs dependencies, downloads the Farsi KG and Graph2Text model,
+# launches a neo4j docker container, and runs an example query.
+
+set -e
+
+# ----------- Configuration -----------
+# Directory to store downloaded resources
+DATA_DIR="data"
+MODEL_DIR="models"
+
+# Neo4j credentials
+NEO4J_USER="neo4j"
+NEO4J_PASSWORD="test"
+NEO4J_CONTAINER="neo4j-farsi"
+NEO4J_PORT_HTTP=7474
+NEO4J_PORT_BOLT=7687
+
+# Property name storing Farsi labels in the neo4j database
+KG_LABEL_PROPERTY="faLabel"  # property storing Farsi labels
+
+# Example query in Farsi
+QUERY="آب و هوای منطقه‌ای که مرکز همایش‌های پنسیلوانیا در آن قرار دارد چیست؟"
+ENTITY="مرکز همایش های پنسیلوانیا"
+LLM_API="https://your-llm-endpoint"
+LLM_API_KEY="your_api_key"
+
+# -------------------------------------
+
+mkdir -p "$DATA_DIR" "$MODEL_DIR"
+
+# 1. Create virtual environment and install dependencies
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install neo4j numpy pandas tqdm matplotlib igraph networkx torch httpx tiktoken requests gdown
+
+# 2. Download Graph2Text model
+if [ ! -d "$MODEL_DIR/graph2text" ]; then
+    gdown 1812Hy9eMHa_h7dQn70N6eQAmKR_x7WDH -O "$MODEL_DIR/graph2text.zip"
+    unzip "$MODEL_DIR/graph2text.zip" -d "$MODEL_DIR/graph2text"
+fi
+
+# Prepare directories for neo4j data and import the sample Wikidata subset
+mkdir -p "$DATA_DIR/neo4j/data" "$DATA_DIR/neo4j/import"
+cp wikidata_sample.cypher "$DATA_DIR/neo4j/import/"
+
+# 3. Launch neo4j docker container and load the sample dataset
+if ! docker ps -a --format '{{.Names}}' | grep -q "^$NEO4J_CONTAINER$"; then
+    docker run -d --name "$NEO4J_CONTAINER" \
+        -p ${NEO4J_PORT_HTTP}:7474 -p ${NEO4J_PORT_BOLT}:7687 \
+        -e NEO4J_AUTH=${NEO4J_USER}/${NEO4J_PASSWORD} \
+        -v "$(pwd)/$DATA_DIR/neo4j/data":/data \
+        -v "$(pwd)/$DATA_DIR/neo4j/import":/import \
+        neo4j:5.15
+else
+    docker start "$NEO4J_CONTAINER"
+fi
+
+# 4. Wait for neo4j to start and import the sample data
+sleep 20
+docker exec "$NEO4J_CONTAINER" cypher-shell -u "$NEO4J_USER" -p "$NEO4J_PASSWORD" -f /import/wikidata_sample.cypher
+
+# 5. Run FastToG with the Farsi KG
+python fasttog.py \
+    --query "$QUERY" \
+    --entity "$ENTITY" \
+    --base_path output \
+    --llm_api "$LLM_API" \
+    --llm_api_key "$LLM_API_KEY" \
+    --graph2text_path "$MODEL_DIR/graph2text" \
+    --kg_api bolt://localhost:${NEO4J_PORT_BOLT} \
+    --kg_user "$NEO4J_USER" \
+    --kg_pw "$NEO4J_PASSWORD" \
+    --kg_label_property "$KG_LABEL_PROPERTY" \
+    --kg_graph_file_name visulize \
+    --community_max_size 4
+

--- a/wikidata_sample.cypher
+++ b/wikidata_sample.cypher
@@ -1,0 +1,13 @@
+CREATE CONSTRAINT entity_nid IF NOT EXISTS FOR (e:Entity) REQUIRE e.nid IS UNIQUE;
+
+MERGE (c:Entity {nid:1})
+  SET c.faLabel='مرکز همایش های پنسیلوانیا';
+
+MERGE (p:Entity {nid:2})
+  SET p.faLabel='فیلادلفیا';
+
+MERGE (cl:Entity {nid:3})
+  SET cl.faLabel='آب و هوای قاره‌ای مرطوب';
+
+MERGE (c)-[:Relation {value:'قرار دارد در'}]->(p);
+MERGE (p)-[:Relation {value:'آب و هوا'}]->(cl);


### PR DESCRIPTION
## Summary
- allow choosing custom label property in `neo4j_client` and expose new `--kg_label_property` CLI argument for Farsi or other languages
- add `run_wikidata_fa.sh` to install dependencies, load a tiny Farsi Wikidata subset and run an example FastToG query
- document how to run the Farsi demo and ship a miniature Neo4j dump (`wikidata_sample.cypher`)

## Testing
- `python -m py_compile fasttog.py kg_client.py`
- `bash -n run_wikidata_fa.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aa0fff75d48331a40aaaf141290a0b