### PR TITLE
Fix module not callable error

### DIFF
--- a/fasttog.py
+++ b/fasttog.py
@@ -19,7 +19,11 @@ from llms_client import llm_client
 from graph2text import graph2text_client
 from community_tool import Community,prims,kruskal
 from visualization import display_selected_community
-from community_algorithm.communities.algorithms import louvain_method,girvan_newman,spectral_clustering,hierarchical_clustering
+# Import algorithm functions directly to avoid module/function name collision
+from community_algorithm.communities.algorithms.louvain_method import louvain_method
+from community_algorithm.communities.algorithms.girvan_newman import girvan_newman
+from community_algorithm.communities.algorithms.spectral_clustering import spectral_clustering
+from community_algorithm.communities.algorithms.hierarchical_clustering import hierarchical_clustering
 
 from enum import Enum
 class Status(Enum):


### PR DESCRIPTION
Fix 'module' object is not callable error by directly importing community algorithm functions.

The previous import `from community_algorithm.communities.algorithms import louvain_method` imported the `louvain_method` module, not the `louvain_method` function. This caused a `TypeError` when `louvain_method` was called as a function at line 69 of `fasttog.py`. The change imports the specific functions directly from their respective files to ensure they are callable.

---
<a href="https://cursor.com/background-agent?bcId=bc-c2b0b5df-bb5b-44bc-b98f-1b8e72e74e14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c2b0b5df-bb5b-44bc-b98f-1b8e72e74e14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

